### PR TITLE
IT-630: Parameterize runner

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -34,6 +34,11 @@ on:
         description: Specific tag to (re)build.
         required: false
         type: string
+      runs-on:
+        description: The platform on which to run this workflow.
+        type: string
+        required: false
+        default: ubuntu-latest
     outputs:
       tags:
         description: The "{image}:{tag}" image tags.
@@ -50,10 +55,7 @@ on:
 
 jobs:
   build-push:
-    # XXX: ubuntu-latest moving to 24.04 might've caused some builds to start segfaulting, in particular:
-    # in cantaloupe-image, with the arm64 build of TurboJPEG.
-    runs-on: ubuntu-22.04
-    #runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runs-on }}
     environment: ${{ inputs.env }}
     outputs:
       image-info: ${{ toJson(steps.image-build.outputs) }}


### PR DESCRIPTION
`ubuntu-latest` moving to 24.04 (https://github.com/actions/runner-images/issues/10636) appears to have caused some builds to start segfaulting, in particular: in cantaloupe-image, with the arm64 build of TurboJPEG... let's parameterize the runner, so it can continue to use `ubuntu-22.04` (for now).