### PR TITLE
ISX-85: Push to ghcr

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -121,7 +121,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ vars.DOCKER_REGISTRY_URL }}/${{ inputs.image-name }}
+          images: |
+            ${{ vars.DOCKER_REGISTRY_URL }}/${{ inputs.image-name }}
+            ${{ inputs.env == 'dev' && format('ghcr.io/{0}/{1}', github.repository_owner, inputs.image-name }}
           tags: ${{ steps.tag-structure.outputs.tags }}
           flavor: |
             ${{ inputs.image-flavor }}
@@ -156,6 +158,8 @@ jobs:
         id: login-prod-ecr
         uses: aws-actions/amazon-ecr-login@v2
       - name: Log in to the GitHub Container registry
+        # TODO: set to prod before merging
+        if: ${{ inputs.env == 'dev' }}
         uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
         with:
           registry: ghcr.io

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -4,6 +4,7 @@ name: Build and Push Image
 permissions:
   id-token: write
   contents: read
+  packages: write
 on:
   # For automated/reusable workflow calls.
   workflow_call:

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -124,7 +124,7 @@ jobs:
         with:
           images: |
             ${{ vars.DOCKER_REGISTRY_URL }}/${{ inputs.image-name }}
-            ${{ inputs.env == 'dev' && 'dev-' }}${{ format('ghcr.io/{0}/{1}', github.repository_owner, inputs.image-name) }}
+            ghcr.io/${{ github.repository_owner }}/${{ inputs.env == 'dev' && 'dev-' }}${{ inputs.image-name }}
           tags: ${{ steps.tag-structure.outputs.tags }}
           flavor: |
             ${{ inputs.image-flavor }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -124,7 +124,7 @@ jobs:
         with:
           images: |
             ${{ vars.DOCKER_REGISTRY_URL }}/${{ inputs.image-name }}
-            ghcr.io/${{ github.repository_owner }}/${{ inputs.env == 'dev' && 'dev-' }}${{ inputs.image-name }}
+            ghcr.io/${{ github.repository_owner }}/${{ inputs.env == 'dev' && 'dev-' || '' }}${{ inputs.image-name }}
           tags: ${{ steps.tag-structure.outputs.tags }}
           flavor: |
             ${{ inputs.image-flavor }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -123,7 +123,7 @@ jobs:
         with:
           images: |
             ${{ vars.DOCKER_REGISTRY_URL }}/${{ inputs.image-name }}
-            ${{ inputs.env == 'dev' && format('ghcr.io/{0}/{1}', github.repository_owner, inputs.image-name }}
+            ${{ inputs.env == 'dev' && format('ghcr.io/{0}/{1}', github.repository_owner, inputs.image-name) }}
           tags: ${{ steps.tag-structure.outputs.tags }}
           flavor: |
             ${{ inputs.image-flavor }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -159,7 +159,7 @@ jobs:
         id: login-prod-ecr
         uses: aws-actions/amazon-ecr-login@v2
       - name: Log in to the GitHub Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -124,7 +124,7 @@ jobs:
         with:
           images: |
             ${{ vars.DOCKER_REGISTRY_URL }}/${{ inputs.image-name }}
-            ${{ inputs.env == 'dev' && 'dev-' }}format('ghcr.io/{0}/{1}', github.repository_owner, inputs.image-name)
+            ${{ inputs.env == 'dev' && 'dev-' }}{{ format('ghcr.io/{0}/{1}', github.repository_owner, inputs.image-name) }}
           tags: ${{ steps.tag-structure.outputs.tags }}
           flavor: |
             ${{ inputs.image-flavor }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -155,6 +155,12 @@ jobs:
         if: ${{ inputs.env == 'dev' }}
         id: login-prod-ecr
         uses: aws-actions/amazon-ecr-login@v2
+      - name: Log in to the GitHub Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       # --- Build and push
       - name: Build and push

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -177,25 +177,3 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           build-args: ${{ inputs.build-args }}
 
-      - name: Extract image names
-        id: image-names
-        run: |
-          METADATA='${{ steps.image-build.outputs.metadata }}'
-          TOGETHER=$(echo "$METADATA" | jq -c '.["image.name"]')
-          cat <<EOF >> $GITHUB_OUTPUT
-          together=$TOGETHER
-          split=$(echo "$TOGETHER" | jq -c '. | split(",")')
-          EOF
-
-      - name: Create summary
-        run: |
-          cat <<EOF >> $GITHUB_STEP_SUMMARY
-          ## Images Pushed
-          | Image  | Tags |
-          | ------------- | ------------- |
-          | $IMAGE_REPO | $(awk -F ":" '{print $NF}' <<< "$TAGS" | sed -z 's/\n/, /g;s/, *$/\n/' ) |
-          EOF
-        env:
-          IMAGE_REPO: ${{ vars.DOCKER_REGISTRY_URL }}/${{ inputs.image-name }}
-          TAGS: ${{ steps.meta.outputs.tags }}
-

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -124,7 +124,7 @@ jobs:
         with:
           images: |
             ${{ vars.DOCKER_REGISTRY_URL }}/${{ inputs.image-name }}
-            ${{ inputs.env == 'dev' && format('ghcr.io/{0}/{1}', github.repository_owner, inputs.image-name) }}
+            ${{ inputs.env == 'dev' && 'dev-' }}format('ghcr.io/{0}/{1}', github.repository_owner, inputs.image-name)
           tags: ${{ steps.tag-structure.outputs.tags }}
           flavor: |
             ${{ inputs.image-flavor }}
@@ -159,8 +159,6 @@ jobs:
         id: login-prod-ecr
         uses: aws-actions/amazon-ecr-login@v2
       - name: Log in to the GitHub Container registry
-        # TODO: set to prod before merging
-        if: ${{ inputs.env == 'dev' }}
         uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
         with:
           registry: ghcr.io

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -124,7 +124,7 @@ jobs:
         with:
           images: |
             ${{ vars.DOCKER_REGISTRY_URL }}/${{ inputs.image-name }}
-            ${{ inputs.env == 'dev' && 'dev-' }}{{ format('ghcr.io/{0}/{1}', github.repository_owner, inputs.image-name) }}
+            ${{ inputs.env == 'dev' && 'dev-' }}${{ format('ghcr.io/{0}/{1}', github.repository_owner, inputs.image-name) }}
           tags: ${{ steps.tag-structure.outputs.tags }}
           flavor: |
             ${{ inputs.image-flavor }}


### PR DESCRIPTION
Pushes images to ghcr and prefixes the image names with `dev-` for the dev builds.

Removing the custom image version messaging since it's no longer accurate and the information is also in the build info summary.